### PR TITLE
Fix: remaining_time_entity doesn't handle device_class: timestamp entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Only `state_entity` is required — everything else is optional. In the visual e
 | `appliance_type` | `auto` (default) \| `washer` \| `dryer` \| `dishwasher`. |
 | `program_entity` / `program_format` | Program/cycle entity. `clean` (default) trims common `"<category> Pr <name>"` patterns; `raw` shows the state as-is. |
 | `remaining_time_entity` / `remaining_time_unit` | Remaining duration. Unit `auto` (default), `seconds`, or `minutes`. |
+| `remaining_time_hide_when_idle` | `true` to only show remaining time while the appliance is running. Prevents stale completion timestamps (e.g. Samsung SmartThings keeping a past finish time after the cycle ends) from displaying. |
 | `progress_entity` | Optional 0–100 sensor; overrides the client-side estimate. |
 | `door_entity` / `door_open_state` / `door_invert` | Door sensor, the state meaning "open" (default `on`), and an invert toggle. |
 | `alerts_entity` | Entity whose *attributes* are on/off flags; any "on/true/active" attribute is shown as an active alert. |

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -32,6 +32,7 @@ const T = {
     program_format_raw: "Raw", program_format_clean: "Cleaned up",
     remaining_time_entity: "Remaining time entity",
     remaining_time_unit: "Remaining time unit",
+    remaining_time_hide_when_idle: "Hide remaining time unless running",
     unit_auto: "Auto-detect", unit_seconds: "Seconds", unit_minutes: "Minutes",
     progress_entity: "Progress % entity (optional override)",
     door_entity: "Door sensor entity",
@@ -643,6 +644,18 @@ function numericState(hass, entityId) {
 function remainingSeconds(hass, entityId, unitCfg) {
   const st = stateObj(hass, entityId);
   if (!st) return null;
+
+  // Handle device_class: timestamp (ISO 8601 datetime) entities, as reported
+  // by integrations like Samsung SmartThings and LG SmartThinQ for cycle end
+  // time. These report an absolute completion time rather than a numeric
+  // duration, so the remaining time must be derived from the difference to now.
+  if (st.attributes.device_class === "timestamp") {
+    const finish = new Date(st.state);
+    if (isNaN(finish)) return null;
+    const diff = (finish - Date.now()) / 1000;
+    return diff > 0 ? diff : 0;
+  }
+
   const v = parseFloat(st.state);
   if (!Number.isFinite(v) || v < 0) return null;
   let unit = unitCfg || "auto";
@@ -846,7 +859,13 @@ class ApplianceCard extends HTMLElement {
     // Remaining time / progress
     let remSec = null;
     if (cfg.remaining_time_entity) {
-      remSec = remainingSeconds(hass, cfg.remaining_time_entity, cfg.remaining_time_unit);
+      // remaining_time_hide_when_idle cross-references the already-normalized
+      // machine state so stale completion timestamps (integrations like
+      // Samsung SmartThings keep reporting a past cycle's finish time after
+      // the appliance goes idle) don't show a leftover "remaining time".
+      if (!cfg.remaining_time_hide_when_idle || norm === "running") {
+        remSec = remainingSeconds(hass, cfg.remaining_time_entity, cfg.remaining_time_unit);
+      }
     }
 
     let progressPct = null;
@@ -1180,7 +1199,7 @@ const SECTIONS = [
         { value: "seconds", label: t(hass, "unit_seconds") },
         { value: "minutes", label: t(hass, "unit_minutes") },
       ],
-    }) },
+    }) + c._row("remaining_time_hide_when_idle", "remaining_time_hide_when_idle", { type: "checkbox" }) },
   { field: "progress_entity", labelKey: "section_progress", includeDomains: ["sensor", "input_number"] },
   { field: "door_entity", labelKey: "section_door", includeDomains: ["binary_sensor", "sensor"], extra: (c, hass) =>
       c._row("door_open_state", "door_open_state", { placeholder: "on" }) +


### PR DESCRIPTION
Fixes #1

## Problem
Samsung SmartThings and LG SmartThinQ report cycle completion time as an ISO 8601 `device_class: timestamp` entity rather than a numeric duration. `remainingSeconds()` ran `parseFloat()` on the state string, which only picked up the leading digits of the year, producing the same nonsense remaining-time value on every card regardless of actual finish time.

## Fix
`remainingSeconds()` now detects `device_class: timestamp` and computes the difference to `now()` directly (clamped to zero for past timestamps, `null` for unparseable ones). Numeric duration entities are unaffected.

## Also included
Added the optional `remaining_time_hide_when_idle` flag discussed in the issue. It cross-references the already-normalized machine state and only computes/shows remaining time while the appliance is `running`, so a stale completion timestamp left over after a cycle ends (a Samsung quirk called out in the issue) doesn't display. Off by default, so existing configs are unaffected.

## Testing
- Verified against the real bug scenario using live Samsung SmartThings data on my own HA instance: a raw `device_class: timestamp` entity now shows the correct remaining time/ETA instead of the old ~2026-minutes bug.
- Verified `remaining_time_hide_when_idle` suppresses a stale completion timestamp while idle, and still shows remaining time while running.
- Regression-tested the existing numeric-duration path (seconds/minutes, auto-detect and explicit unit) to confirm it's unaffected.
- Edited `dist/ha-appliance-card.js` directly per your note that it's the source of truth in this repo; `node --check` passes and the changed lines are plain ASCII.

Also added a README row documenting `remaining_time_hide_when_idle`.