### PR TITLE
Add Norwegian Bokmal alias and dishwasher illustration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ No brand assumed: every field is a configurable entity mapping, so it works with
 - **Program, info lines** (temperature, spin speed…), **door, alerts, connectivity** (top-right wifi icon), each optional and independent.
 - **Start / pause / resume / stop** controls, only shown for the entities you configure.
 - **Sizes itself in Sections dashboards**: the card declares its own width and height, so it isn't squeezed into wrapping its info lines.
-- **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale.
+- **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale. Norwegian Bokmål is accepted under both `nb`/`nb-NO` and the existing `no` translation key.
 - **Visual editor**: pick the state entity and the other fields are auto-suggested from sibling entities on the same device.
 
-Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams.
+Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams. The dishwasher has its own front-loading illustration with a square, bottom-hinged door, visible plates, a rotating spray arm, droplets and water waves while running.
 
 ![Animated appliance types](https://raw.githubusercontent.com/ADNPolymerase/ha-appliance-card/main/docs/animated.gif)
 
@@ -63,7 +63,7 @@ Only `state_entity` is required; everything else is optional. A fridge is the ex
 | `state_show_raw` | `true` to display the raw state text instead of the translated label (color/animation still follow the detected category). |
 | `name` | Card title. Defaults to the state entity's friendly name. |
 | `compact` | `true` to hide the illustration and show only text. |
-| `language` | `auto` (default) follows Home Assistant. Any of the fourteen shipped codes (`en`, `fr`, `de`, `es`, `it`, `nl`, `pt`, `sv`, `no`, `da`, `pl`, `ru`, `zh`, `cs`) pins this card, and its editor, to that language instead. For running Home Assistant in one language while reading a card in another. |
+| `language` | `auto` (default) follows Home Assistant. Any of the fourteen shipped codes (`en`, `fr`, `de`, `es`, `it`, `nl`, `pt`, `sv`, `no`, `da`, `pl`, `ru`, `zh`, `cs`) pins this card, and its editor, to that language instead. Norwegian Bokmål also accepts `nb` and `nb-NO`, which resolve to the existing Norwegian translation. |
 | `appliance_type` | `auto` (default) \| `washer` \| `dryer` \| `dishwasher` \| `oven` \| `microwave` \| `hood` \| `cooktop` \| `fridge` \| `kettle` \| `cooker` \| `coffee` \| `rice_cooker`. The visual editor only offers the fields the chosen type can use. |
 | `toggle_entity` | On/off control, shown as a power button on the card and highlighted while on. Any `switch`/`button`/`script`/`input_boolean`/`fan`. Named this way so it is not mistaken for `power_entity` below, which is the wattage meter. |
 | `power_entity` / `power_on_threshold` / `power_icon` | Power sensor (W). With a threshold set, the state is derived from it instead of `state_entity`: above the threshold is *running*, and falling back below it is *finished* until the next run. Pointing `state_entity` at the same power sensor enables this on its own, with a default threshold of 10 W. `power_icon` overrides the default `mdi:power-plug`. |

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -1,4 +1,4 @@
-const CARD_VERSION = "2.2.1";
+const CARD_VERSION = "2.2.1-nb-poc";
 
 console.info(
   "%c HA-APPLIANCE-CARD %c v" + CARD_VERSION + " ",
@@ -897,7 +897,7 @@ const T = {
     idle: "Inaktiv", running: "I gang", paused: "Pauset", done: "Ferdig",
     delayed: "Utsatt start", error: "Feil", unknown: "Ukjent",
     program: "Program", remaining: "gjenst\u00e5r", ready_at: "ferdig kl.", time_done: "Ferdig",
-    door_open: "Luke \u00e5pen", door_closed: "Luke lukket", alerts: "Varsler",
+    door_open: "D\u00f8r \u00e5pen", door_closed: "D\u00f8r lukket", alerts: "Varsler",
     connected: "Tilkoblet", disconnected: "Frakoblet",
     start: "Start", pause: "Pause", resume: "Gjenoppta", stop: "Stopp",
     name: "Navn", icon: "Ikon", entity: "Entitet",
@@ -1385,9 +1385,15 @@ const T = {
   },
 };
 
+function canonicalLanguage(code) {
+  const base = String(code || "en").toLowerCase().split("-")[0];
+  // Home Assistant uses nb/nb-NO for Norwegian Bokmal. The card's existing
+  // translation is kept under no for backwards compatibility, so treat both
+  // identifiers as the same language instead of falling back to English.
+  return base === "nb" ? "no" : base;
+}
 function lang(hass) {
-  const l = String((hass && ((hass.locale && hass.locale.language) || hass.language)) || "en")
-    .toLowerCase().split("-")[0];
+  const l = canonicalLanguage(hass && ((hass.locale && hass.locale.language) || hass.language));
   return T[l] ? l : "en";
 }
 function t(hass, key) {
@@ -1410,8 +1416,9 @@ const LANGUAGE_NAMES = {
 // the choice to the dates as well, which share the same resolution.
 function localizedHass(hass, cfg) {
   const want = cfg && cfg.language;
-  if (!hass || !want || want === "auto" || !T[want]) return hass;
-  return { ...hass, language: want, locale: { ...(hass.locale || {}), language: want } };
+  const resolved = canonicalLanguage(want);
+  if (!hass || !want || want === "auto" || !T[resolved]) return hass;
+  return { ...hass, language: resolved, locale: { ...(hass.locale || {}), language: resolved } };
 }
 
 // ---------------------------------------------------------------------------
@@ -2208,6 +2215,136 @@ const ILLUSTRATION_CSS = {
           to { transform: translate(-50%, -50%) rotate(360deg); }
         }
   `,
+  dishwasher: (color) => `
+        /* A dishwasher is front-loading, but its door hinges at the bottom.
+           Keep the same compact, CSS-only visual language as the other types. */
+        .dw-body {
+          position: absolute; inset: 0; border-radius: 10px 10px 6px 6px;
+          background: linear-gradient(145deg, var(--secondary-background-color, #d7d7d7), #aeb2b5);
+          border: 1px solid var(--divider-color, #c7c7c7);
+          perspective: 260px;
+        }
+        .dw-controls {
+          position: absolute; top: 6px; left: 8px; right: 8px; height: 12px;
+          border: 1px solid rgba(255, 255, 255, 0.14); border-radius: 3px;
+          background: rgba(20, 22, 23, 0.78);
+        }
+        .dw-controls::before,
+        .dw-controls::after {
+          content: ""; position: absolute; top: 3px; width: 4px; height: 4px;
+          border-radius: 50%; background: #697078;
+        }
+        .dw-controls::before { right: 5px; }
+        .dw-controls::after { right: 12px; }
+        .dw-screen {
+          position: absolute; top: 2px; left: 4px; width: 24px; height: 6px;
+          border-radius: 2px; background: #16292e;
+          box-shadow: inset 0 0 0 1px rgba(129, 213, 205, 0.3);
+        }
+        .dw-cavity {
+          position: absolute; top: 22px; right: 8px; bottom: 8px; left: 8px;
+          overflow: hidden; border: 3px solid #34383b; border-radius: 4px;
+          background: linear-gradient(180deg, #1c2931, #5d6d73);
+          box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.58);
+        }
+        .dw-rack {
+          position: absolute; right: 10%; bottom: 13%; left: 10%; height: 34%;
+          border-top: 1px solid rgba(222, 232, 235, 0.76);
+          border-bottom: 1px solid rgba(222, 232, 235, 0.5);
+          background: repeating-linear-gradient(90deg, transparent 0 7px, rgba(222, 232, 235, 0.58) 8px 9px);
+          transform: perspective(100px) rotateX(18deg);
+        }
+        .dw-dishes {
+          position: absolute; right: 15%; bottom: 17%; left: 15%; z-index: 1; height: 43%;
+        }
+        .dw-plate {
+          position: absolute; bottom: 0; width: 9px; height: 18px;
+          border: 1px solid rgba(240, 242, 244, 0.62); border-radius: 50%;
+          background: linear-gradient(90deg, transparent 0 28%, rgba(240, 242, 244, 0.14) 50%, transparent 72%);
+          box-shadow: inset 0 0 0 1px rgba(240, 242, 244, 0.12);
+        }
+        .dw-plate-a { left: 0; transform: rotate(-12deg); }
+        .dw-plate-b { left: 23%; transform: rotate(-5deg); }
+        .dw-plate-c { left: 47%; transform: rotate(5deg); }
+        .dw-plate-d { right: 0; transform: rotate(12deg); }
+        .dw-spray {
+          position: absolute; top: 21%; left: 16%; width: 68%; height: 3px; z-index: 3;
+          border-radius: 999px;
+          background: linear-gradient(90deg, transparent, ${color}, transparent);
+          opacity: 0.42; transform-origin: 50% 50%; transition: opacity 0.3s ease;
+        }
+        .dw-spray::before,
+        .dw-spray::after {
+          content: ""; position: absolute; top: 1px; width: 2px; height: 1px;
+          border-radius: 50%; background: ${color};
+        }
+        .dw-spray::before { left: 22%; }
+        .dw-spray::after { right: 22%; }
+        .dw-spray-hub {
+          position: absolute; top: 50%; left: 50%; width: 7px; height: 7px;
+          border: 1px solid ${color}; border-radius: 50%; background: #2c2c2c;
+          transform: translate(-50%, -50%);
+        }
+        .dw-drops { position: absolute; inset: 0; z-index: 4; pointer-events: none; }
+        .dw-drop {
+          position: absolute; top: 22%; width: 3px; height: 5px; border-radius: 60%;
+          background: ${color}; opacity: 0; transform: translateY(-4px) scale(0.8);
+        }
+        .dw-drop-a { left: 25%; }
+        .dw-drop-b { left: 38%; }
+        .dw-drop-c { left: 51%; }
+        .dw-drop-d { left: 64%; }
+        .dw-drop-e { left: 75%; }
+        .dw-water {
+          position: absolute; right: 9%; bottom: 5%; left: 9%; z-index: 2; height: 12px;
+          overflow: hidden; border-top: 1px solid ${color}; border-radius: 50% 50% 20% 20%;
+          background: linear-gradient(180deg, rgba(33, 150, 243, 0.22), transparent 86%);
+          opacity: 0.5; transition: opacity 0.3s ease;
+        }
+        .dw-wave {
+          position: absolute; left: -8%; width: 116%; height: 7px;
+          border-top: 1px solid ${color}; border-radius: 50%;
+        }
+        .dw-wave-a { top: 2px; }
+        .dw-wave-b { top: 6px; left: 8%; opacity: 0.6; }
+        .machine.spinning .dw-spray { opacity: 0.95; animation: dw-spray-spin 2.8s linear infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-drop { animation: dw-drop-fall 1.65s ease-in infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-drop-a { animation-delay: calc(-0.3s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-b { animation-delay: calc(-0.95s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-c { animation-delay: calc(-0.58s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-d { animation-delay: calc(-1.15s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-e { animation-delay: calc(-0.76s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-water { opacity: 0.82; animation: dw-water-pulse 2.2s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-wave-a { animation: dw-wave-drift 1.8s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-wave-b { animation: dw-wave-drift 2.4s ease-in-out infinite reverse; animation-delay: var(--anim-offset, 0s); }
+        .dw-door {
+          position: absolute; top: 22px; right: 8px; bottom: 8px; left: 8px; z-index: 5;
+          padding: 0; border: 3px solid #34383b; border-radius: 4px;
+          background: linear-gradient(180deg, rgba(30, 37, 39, 0.15), rgba(30, 37, 39, 0.65));
+          box-shadow: 0 3px 5px rgba(0, 0, 0, 0.25); transform-origin: 50% 100%;
+          transition: transform 0.42s cubic-bezier(.2, .75, .25, 1), box-shadow 0.42s ease;
+        }
+        .dw-door::before {
+          content: ""; position: absolute; top: 4px; right: 18%; left: 18%; height: 2px;
+          border-radius: 8px; background: rgba(225, 231, 232, 0.6);
+        }
+        .dw-door.open { transform: rotateX(66deg) translateY(7px) translateZ(4px); box-shadow: 0 12px 10px rgba(0, 0, 0, 0.32); }
+        @keyframes dw-spray-spin { to { transform: rotate(360deg); } }
+        @keyframes dw-drop-fall {
+          0% { opacity: 0; transform: translateY(-4px) scale(0.75); }
+          22% { opacity: 0.85; }
+          82% { opacity: 0.62; }
+          100% { opacity: 0; transform: translateY(28px) scale(1); }
+        }
+        @keyframes dw-water-pulse { 0%, 100% { transform: scaleX(0.97); } 50% { transform: scaleX(1.02); } }
+        @keyframes dw-wave-drift { 0%, 100% { transform: translateX(-3%); } 50% { transform: translateX(3%); } }
+        @media (prefers-reduced-motion: reduce) {
+          .machine.spinning .dw-spray, .machine.spinning .dw-drop, .machine.spinning .dw-water,
+          .machine.spinning .dw-wave-a, .machine.spinning .dw-wave-b {
+          animation-duration: 0.001ms !important; animation-iteration-count: 1 !important;
+          }
+        }
+  `,
   oven: () => `
         .ov-body {
           position: absolute; inset: 0; border-radius: 10px;
@@ -2806,7 +2943,7 @@ const ILLUSTRATION_CSS = {
 };
 
 function illustrationCss(type, color) {
-  const family = LAUNDRY_TYPES.includes(type) ? "laundry" : type;
+  const family = type === "dishwasher" ? "dishwasher" : LAUNDRY_TYPES.includes(type) ? "laundry" : type;
   const fn = ILLUSTRATION_CSS[family] || ILLUSTRATION_CSS.laundry;
   return fn(color);
 }
@@ -2941,6 +3078,34 @@ function illustrationHtml(type, ctx) {
     .filter(Boolean)
     .join(" ");
 
+  if (type === "dishwasher") {
+    return `
+        <div class="machine ${ctx.spinning ? "spinning" : ""}">
+          <div class="dw-body">
+            <div class="dw-controls"><div class="dw-screen"></div></div>
+            <div class="dw-cavity">
+              <div class="dw-dishes" aria-hidden="true">
+                <span class="dw-plate dw-plate-a"></span>
+                <span class="dw-plate dw-plate-b"></span>
+                <span class="dw-plate dw-plate-c"></span>
+                <span class="dw-plate dw-plate-d"></span>
+              </div>
+              <div class="dw-rack"></div>
+              <div class="dw-spray" aria-hidden="true"><span class="dw-spray-hub"></span></div>
+              <div class="dw-drops" aria-hidden="true">
+                <i class="dw-drop dw-drop-a"></i><i class="dw-drop dw-drop-b"></i>
+                <i class="dw-drop dw-drop-c"></i><i class="dw-drop dw-drop-d"></i>
+                <i class="dw-drop dw-drop-e"></i>
+              </div>
+              <div class="dw-water" aria-hidden="true">
+                <span class="dw-wave dw-wave-a"></span><span class="dw-wave dw-wave-b"></span>
+              </div>
+            </div>
+            <div class="dw-door ${ctx.doorOpen ? "open" : ""}" aria-hidden="true"></div>
+          </div>
+        </div>`;
+  }
+
   if (LAUNDRY_TYPES.includes(type)) {
     const glassContent = {
       washer: `
@@ -2954,7 +3119,6 @@ function illustrationHtml(type, ctx) {
           <div class="garment g2"></div>
           <div class="garment g3"></div>
         </div>`,
-      dishwasher: `<div class="spray-arm"></div>`,
     }[type];
     return `
         <div class="machine ${ctx.spinning ? "spinning" : ""}">


### PR DESCRIPTION
## Summary

This PR adds two improvements to the appliance card:

- Accept `nb` and `nb-NO` as Norwegian Bokmål locale identifiers, reusing the existing Norwegian translations instead of falling back to English.
- Add a dedicated dishwasher illustration with:
  - A square, bottom-hinged door
  - Visible plates in the rack
  - A rotating spray arm while running
  - Water droplets and animated water waves
  - Norwegian labels using “Dør åpen” and “Dør lukket”

The dishwasher illustration remains CSS-only and follows the existing compact visual language used by the other appliance types. No external dependencies are added.

## Testing

- Tested locally in Home Assistant with `language: nb`
- `node --check dist/ha-appliance-card.js`
- `node test/run.mjs`
- All 360 assertions pass