### PR TITLE
fix: accept Norwegian Bokmal locale aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ No brand assumed: every field is a configurable entity mapping, so it works with
 - **Program, info lines** (temperature, spin speed…), **door, alerts, connectivity** (top-right wifi icon), each optional and independent.
 - **Start / pause / resume / stop** controls, only shown for the entities you configure.
 - **Sizes itself in Sections dashboards**: the card declares its own width and height, so it isn't squeezed into wrapping its info lines.
-- **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale.
+- **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale. Norwegian Bokmal is accepted under both `nb`/`nb-NO` and the existing `no` translation key.
 - **Visual editor**: pick the state entity and the other fields are auto-suggested from sibling entities on the same device.
 
 Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams.
@@ -63,7 +63,7 @@ Only `state_entity` is required; everything else is optional. A fridge is the ex
 | `state_show_raw` | `true` to display the raw state text instead of the translated label (color/animation still follow the detected category). |
 | `name` | Card title. Defaults to the state entity's friendly name. |
 | `compact` | `true` to hide the illustration and show only text. |
-| `language` | `auto` (default) follows Home Assistant. Any of the fourteen shipped codes (`en`, `fr`, `de`, `es`, `it`, `nl`, `pt`, `sv`, `no`, `da`, `pl`, `ru`, `zh`, `cs`) pins this card, and its editor, to that language instead. For running Home Assistant in one language while reading a card in another. |
+| `language` | `auto` (default) follows Home Assistant. Any of the fourteen shipped codes (`en`, `fr`, `de`, `es`, `it`, `nl`, `pt`, `sv`, `no`, `da`, `pl`, `ru`, `zh`, `cs`) pins this card, and its editor, to that language instead. Norwegian Bokmal also accepts `nb` and `nb-NO`, which resolve to the existing Norwegian translation. |
 | `appliance_type` | `auto` (default) \| `washer` \| `dryer` \| `dishwasher` \| `oven` \| `microwave` \| `hood` \| `cooktop` \| `fridge` \| `kettle` \| `cooker` \| `coffee` \| `rice_cooker`. The visual editor only offers the fields the chosen type can use. |
 | `toggle_entity` | On/off control, shown as a power button on the card and highlighted while on. Any `switch`/`button`/`script`/`input_boolean`/`fan`. Named this way so it is not mistaken for `power_entity` below, which is the wattage meter. |
 | `power_entity` / `power_on_threshold` / `power_icon` | Power sensor (W). With a threshold set, the state is derived from it instead of `state_entity`: above the threshold is *running*, and falling back below it is *finished* until the next run. Pointing `state_entity` at the same power sensor enables this on its own, with a default threshold of 10 W. `power_icon` overrides the default `mdi:power-plug`. |

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -897,7 +897,7 @@ const T = {
     idle: "Inaktiv", running: "I gang", paused: "Pauset", done: "Ferdig",
     delayed: "Utsatt start", error: "Feil", unknown: "Ukjent",
     program: "Program", remaining: "gjenst\u00e5r", ready_at: "ferdig kl.", time_done: "Ferdig",
-    door_open: "Luke \u00e5pen", door_closed: "Luke lukket", alerts: "Varsler",
+    door_open: "D\u00f8r \u00e5pen", door_closed: "D\u00f8r lukket", alerts: "Varsler",
     connected: "Tilkoblet", disconnected: "Frakoblet",
     start: "Start", pause: "Pause", resume: "Gjenoppta", stop: "Stopp",
     name: "Navn", icon: "Ikon", entity: "Entitet",
@@ -1385,9 +1385,15 @@ const T = {
   },
 };
 
+function canonicalLanguage(code) {
+  const base = String(code || "en").toLowerCase().split("-")[0];
+  // Home Assistant uses nb/nb-NO for Norwegian Bokmal. The card's existing
+  // translation is kept under no for backwards compatibility, so treat both
+  // identifiers as the same language instead of falling back to English.
+  return base === "nb" ? "no" : base;
+}
 function lang(hass) {
-  const l = String((hass && ((hass.locale && hass.locale.language) || hass.language)) || "en")
-    .toLowerCase().split("-")[0];
+  const l = canonicalLanguage(hass && ((hass.locale && hass.locale.language) || hass.language));
   return T[l] ? l : "en";
 }
 function t(hass, key) {
@@ -1410,8 +1416,9 @@ const LANGUAGE_NAMES = {
 // the choice to the dates as well, which share the same resolution.
 function localizedHass(hass, cfg) {
   const want = cfg && cfg.language;
-  if (!hass || !want || want === "auto" || !T[want]) return hass;
-  return { ...hass, language: want, locale: { ...(hass.locale || {}), language: want } };
+  const resolved = canonicalLanguage(want);
+  if (!hass || !want || want === "auto" || !T[resolved]) return hass;
+  return { ...hass, language: resolved, locale: { ...(hass.locale || {}), language: resolved } };
 }
 
 // ---------------------------------------------------------------------------

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -1350,6 +1350,12 @@ check('langue : auto revient au reglage de Home Assistant',
 // A code the card does not ship must not blank the card out.
 check('langue : un code inconnu retombe sur Home Assistant',
   stateLine(inHa('fr', { ...base, language: 'xx' }, WASH)), 'En cours');
+check('locale nb : resolue vers le bloc no',
+  stateLine(inHa('nb', base, WASH)), 'I gang');
+check('locale nb-NO : resolue vers le bloc no',
+  stateLine(inHa('nb-NO', base, WASH)), 'I gang');
+check('langue : forcee en bokmal malgre un HA anglais',
+  stateLine(inHa('en', { ...base, language: 'nb' }, WASH)), 'I gang');
 // Overriding the locale must not disturb anything else read from hass.
 contains('langue : les entites restent lues normalement',
   inHa('en', { ...base, language: 'fr' }, WASH), 'mdi:door-closed');


### PR DESCRIPTION
Follow-up to #9, split out as requested in review.

## Summary

- accept Home Assistant's nb and nb-NO locale identifiers, including regional and mixed-case variants
- keep the existing no translation block as the canonical Norwegian translation
- apply the canonical locale in both the card renderer and localizedHass() so per-card language: nb also works
- use the shared Norwegian labels Dør åpen and Dør lukket
- restore CARD_VERSION to 2.2.1 for the release maintainer to bump
- document the supported aliases in README.md

## Tests

- node --check dist/ha-appliance-card.js
- node test/run.mjs
- 363/363 assertions pass
- dist/ha-appliance-card.js remains ASCII-only