### PR TITLE
feat: add dedicated dishwasher illustration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ No brand assumed: every field is a configurable entity mapping, so it works with
 - **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale.
 - **Visual editor**: pick the state entity and the other fields are auto-suggested from sibling entities on the same device.
 
-Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams.
+Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams. The dishwasher has its own front-loading illustration with a square, bottom-hinged door, visible plates, a rotating spray arm, droplets and water waves while running.
 
 ![Animated appliance types](https://raw.githubusercontent.com/ADNPolymerase/ha-appliance-card/main/docs/animated.gif)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ No brand assumed: every field is a configurable entity mapping, so it works with
 ## Features
 
 - **State normalization**: `Idle`, `RUNNING`, `wash`, `En marche`… are auto-detected (accent-insensitive) and mapped to idle / preheating / running / paused / done / delayed / error. An unmatched state is shown as it came, minus the namespace an integration wraps it in: `BSH.Common.EnumType.OperationState.ActionRequired` reads `Action Required`. `state_map` classifies whatever is left.
-- **Twelve appliance types**, each with its own animated illustration: washer (water), dryer (tumbling), dishwasher (spray arm), oven (glowing elements, door dropping open), microwave (turntable, lit cavity), cooker hood (rising airflow, light beams), cooktop (per-zone level and residual heat), fridge (each door swings for its own sensor, lit interior, falling ice cubes), kettle (glowing base, bubbles, steam), cooker (turning blade, hot element, steam), coffee machine (pouring stream, filling cup, tank level) and rice cooker (steam, keep-warm glow). Static when idle, auto-detected or set via `appliance_type`. `compact: true` keeps only the text.
+- **Twelve appliance types**, each with its own animated illustration: washer (water), dryer (tumbling), dishwasher (spray arm, plates, bottom-hinged door and phase-aware drying), oven (glowing elements, door dropping open), microwave (turntable, lit cavity), cooker hood (rising airflow, light beams), cooktop (per-zone level and residual heat), fridge (each door swings for its own sensor, lit interior, falling ice cubes), kettle (glowing base, bubbles, steam), cooker (turning blade, hot element, steam), coffee machine (pouring stream, filling cup, tank level) and rice cooker (steam, keep-warm glow). Static when idle, auto-detected or set via `appliance_type`. `compact: true` keeps only the text.
 - **A coffee machine says what it needs**: an empty tank, an empty bean container, a full drip tray or a due descaling takes over the state line whenever the machine isn't actually pouring, in the order in which each one stops you getting a coffee. Only what needs doing takes a line.
 - **A fridge reports its health, not a cycle**: it never stops, so *Running* would be true of it every hour of its life. The state line carries the one thing worth reading instead, in order of what it costs to miss: unplugged, a door left open, a temperature above the limit, otherwise normal. Read-only, with no buttons to press.
 - **Works from a smart plug alone**: set `power_entity` + `power_on_threshold` and the state is derived from consumption (standby → running → finished), with no appliance integration at all.
@@ -33,7 +33,7 @@ No brand assumed: every field is a configurable entity mapping, so it works with
 - **Interface translated into 14 languages** (EN, FR, DE, ES, IT, NL, PT, SV, NO, DA, PL, RU, ZH, CS), picked up from the Home Assistant locale.
 - **Visual editor**: pick the state entity and the other fields are auto-suggested from sibling entities on the same device.
 
-Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams. The dishwasher has its own front-loading illustration with a square, bottom-hinged door, visible plates, a rotating spray arm, droplets and water waves while running.
+Illustrations are CSS, not images, and they animate on the appliance's own data: the blade turns once per pulse at the speed the cooker reports, coffee pours into one cup or two, ice cubes fall while the maker runs, a kettle bubbles and steams. The dishwasher has its own front-loading illustration with a square, bottom-hinged door, visible plates, a rotating spray arm, droplets and water waves while running. When `phase_entity` reports `Drying`, the closed machine shows internal heat and a fan; `Ado Drying` shows heat rising from the top of the door. Unknown or unavailable phase values keep the normal animation.
 
 ![Animated appliance types](https://raw.githubusercontent.com/ADNPolymerase/ha-appliance-card/main/docs/animated.gif)
 
@@ -68,6 +68,7 @@ Only `state_entity` is required; everything else is optional. A fridge is the ex
 | `toggle_entity` | On/off control, shown as a power button on the card and highlighted while on. Any `switch`/`button`/`script`/`input_boolean`/`fan`. Named this way so it is not mistaken for `power_entity` below, which is the wattage meter. |
 | `power_entity` / `power_on_threshold` / `power_icon` | Power sensor (W). With a threshold set, the state is derived from it instead of `state_entity`: above the threshold is *running*, and falling back below it is *finished* until the next run. Pointing `state_entity` at the same power sensor enables this on its own, with a default threshold of 10 W. `power_icon` overrides the default `mdi:power-plug`. |
 | `program_entity` / `program_format` | Program/cycle entity. `clean` (default) trims the common `"<category> Pr <name>"` pattern, drops the namespace off a fully qualified Home Connect enum (`LaundryCare.Washer.Program.Auto40` reads as *Auto 40*), and separates a temperature or a duration run into the name (`Rapid20Min` reads as *Rapid 20 Min*). `raw` shows the state as-is. |
+| `phase_entity` / `phase_map` | Optional dishwasher cycle-phase entity and raw-value map. Known phases include `Prewash`, `Mainwash`, `Drying` and `Ado Drying`; `Drying` shows internal heat/fan animation and `Ado Drying` shows heat escaping at the door. Missing, unavailable or unknown values are ignored safely. |
 | `remaining_time_entity` / `remaining_time_unit` | Remaining duration. Unit `auto` (default), `seconds`, or `minutes`. |
 | `remaining_time_hide_when_idle` | `true` to only show remaining time while the appliance is running. Prevents stale completion timestamps (e.g. Samsung SmartThings keeping a past finish time after the cycle ends) from displaying. |
 | `progress_entity` | Optional 0–100 sensor; overrides the client-side estimate. |
@@ -197,6 +198,26 @@ In the visual editor the same thing is edited as one `code: label` per line,
 under each info entity. `=` also works as the separator, blank lines and lines
 starting with `#` are ignored, and only the first `:` or `=` splits the line so
 a label may itself contain one.
+
+### Dishwasher phase animation
+
+The phase entity is optional. If the integration exposes the dishwasher phase,
+add it directly or provide an explicit map for vendor-specific values:
+
+```yaml
+appliance_type: dishwasher
+state_entity: sensor.dishwasher_state
+phase_entity: sensor.dishwasher_cycle_phase
+phase_map:
+  Prewash: prewash
+  Mainwash: mainwash
+  Drying: drying
+  Ado Drying: ado_drying
+```
+
+The built-in aliases recognise these values without `phase_map` as well. The
+phase only changes the illustration; it does not replace the appliance state
+or door sensor.
 
 ## Thanks
 

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -2189,23 +2189,136 @@ const ILLUSTRATION_CSS = {
         .garment.g3 { top: 15px; left: 36px; transform: rotate(-25deg); }
         .machine.spinning .garments { animation: tumble 2.6s linear infinite; animation-delay: var(--anim-offset, 0s); }
         @keyframes tumble { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
-        .spray-arm {
-          position: absolute; top: 50%; left: 50%; width: 3px; height: 72%;
-          background: ${color}; transform: translate(-50%, -50%); transform-origin: center;
-          transition: background 1s linear;
+  `,
+  dishwasher: (color) => `
+        /* A dishwasher is front-loading, but its door hinges at the bottom.
+           Keep the same compact, CSS-only visual language as the other types. */
+        .dw-body {
+          position: absolute; inset: 0; border-radius: 10px 10px 6px 6px;
+          background: linear-gradient(145deg, var(--secondary-background-color, #d7d7d7), #aeb2b5);
+          border: 1px solid var(--divider-color, #c7c7c7);
+          perspective: 260px;
         }
-        .spray-arm::before {
-          content: ""; position: absolute; top: 50%; left: 50%; width: 72%; height: 3px;
-          background: ${color}; transform: translate(-50%, -50%);
+        .dw-controls {
+          position: absolute; top: 6px; left: 8px; right: 8px; height: 12px;
+          border: 1px solid rgba(255, 255, 255, 0.14); border-radius: 3px;
+          background: rgba(20, 22, 23, 0.78);
         }
-        .spray-arm::after {
-          content: ""; position: absolute; top: 50%; left: 50%; width: 6px; height: 6px;
-          border-radius: 50%; background: ${color}; transform: translate(-50%, -50%);
+        .dw-controls::before,
+        .dw-controls::after {
+          content: ""; position: absolute; top: 3px; width: 4px; height: 4px;
+          border-radius: 50%; background: #697078;
         }
-        .machine.spinning .spray-arm { animation: spray-spin 0.7s linear infinite; animation-delay: var(--anim-offset, 0s); }
-        @keyframes spray-spin {
-          from { transform: translate(-50%, -50%) rotate(0deg); }
-          to { transform: translate(-50%, -50%) rotate(360deg); }
+        .dw-controls::before { right: 5px; }
+        .dw-controls::after { right: 12px; }
+        .dw-screen {
+          position: absolute; top: 2px; left: 4px; width: 24px; height: 6px;
+          border-radius: 2px; background: #16292e;
+          box-shadow: inset 0 0 0 1px rgba(129, 213, 205, 0.3);
+        }
+        .dw-cavity {
+          position: absolute; top: 22px; right: 8px; bottom: 8px; left: 8px;
+          overflow: hidden; border: 3px solid #34383b; border-radius: 4px;
+          background: linear-gradient(180deg, #1c2931, #5d6d73);
+          box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.58);
+        }
+        .dw-rack {
+          position: absolute; right: 10%; bottom: 13%; left: 10%; height: 34%;
+          border-top: 1px solid rgba(222, 232, 235, 0.76);
+          border-bottom: 1px solid rgba(222, 232, 235, 0.5);
+          background: repeating-linear-gradient(90deg, transparent 0 7px, rgba(222, 232, 235, 0.58) 8px 9px);
+          transform: perspective(100px) rotateX(18deg);
+        }
+        .dw-dishes {
+          position: absolute; right: 15%; bottom: 17%; left: 15%; z-index: 1; height: 43%;
+        }
+        .dw-plate {
+          position: absolute; bottom: 0; width: 9px; height: 18px;
+          border: 1px solid rgba(240, 242, 244, 0.62); border-radius: 50%;
+          background: linear-gradient(90deg, transparent 0 28%, rgba(240, 242, 244, 0.14) 50%, transparent 72%);
+          box-shadow: inset 0 0 0 1px rgba(240, 242, 244, 0.12);
+        }
+        .dw-plate-a { left: 0; transform: rotate(-12deg); }
+        .dw-plate-b { left: 23%; transform: rotate(-5deg); }
+        .dw-plate-c { left: 47%; transform: rotate(5deg); }
+        .dw-plate-d { right: 0; transform: rotate(12deg); }
+        .dw-spray {
+          position: absolute; top: 21%; left: 16%; width: 68%; height: 3px; z-index: 3;
+          border-radius: 999px;
+          background: linear-gradient(90deg, transparent, ${color}, transparent);
+          opacity: 0.42; transform-origin: 50% 50%; transition: opacity 0.3s ease;
+        }
+        .dw-spray::before,
+        .dw-spray::after {
+          content: ""; position: absolute; top: 1px; width: 2px; height: 1px;
+          border-radius: 50%; background: ${color};
+        }
+        .dw-spray::before { left: 22%; }
+        .dw-spray::after { right: 22%; }
+        .dw-spray-hub {
+          position: absolute; top: 50%; left: 50%; width: 7px; height: 7px;
+          border: 1px solid ${color}; border-radius: 50%; background: #2c2c2c;
+          transform: translate(-50%, -50%);
+        }
+        .dw-drops { position: absolute; inset: 0; z-index: 4; pointer-events: none; }
+        .dw-drop {
+          position: absolute; top: 22%; width: 3px; height: 5px; border-radius: 60%;
+          background: ${color}; opacity: 0; transform: translateY(-4px) scale(0.8);
+        }
+        .dw-drop-a { left: 25%; }
+        .dw-drop-b { left: 38%; }
+        .dw-drop-c { left: 51%; }
+        .dw-drop-d { left: 64%; }
+        .dw-drop-e { left: 75%; }
+        .dw-water {
+          position: absolute; right: 9%; bottom: 5%; left: 9%; z-index: 2; height: 12px;
+          overflow: hidden; border-top: 1px solid ${color}; border-radius: 50% 50% 20% 20%;
+          background: linear-gradient(180deg, rgba(33, 150, 243, 0.22), transparent 86%);
+          opacity: 0.5; transition: opacity 0.3s ease;
+        }
+        .dw-wave {
+          position: absolute; left: -8%; width: 116%; height: 7px;
+          border-top: 1px solid ${color}; border-radius: 50%;
+        }
+        .dw-wave-a { top: 2px; }
+        .dw-wave-b { top: 6px; left: 8%; opacity: 0.6; }
+        .machine.spinning .dw-spray { opacity: 0.95; animation: dw-spray-spin 2.8s linear infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-drop { animation: dw-drop-fall 1.65s ease-in infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-drop-a { animation-delay: calc(-0.3s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-b { animation-delay: calc(-0.95s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-c { animation-delay: calc(-0.58s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-d { animation-delay: calc(-1.15s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-drop-e { animation-delay: calc(-0.76s + var(--anim-offset, 0s)); }
+        .machine.spinning .dw-water { opacity: 0.82; animation: dw-water-pulse 2.2s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-wave-a { animation: dw-wave-drift 1.8s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
+        .machine.spinning .dw-wave-b { animation: dw-wave-drift 2.4s ease-in-out infinite reverse; animation-delay: var(--anim-offset, 0s); }
+        .dw-door {
+          position: absolute; top: 22px; right: 8px; bottom: 8px; left: 8px; z-index: 5;
+          padding: 0; border: 3px solid #34383b; border-radius: 4px;
+          background: linear-gradient(180deg, rgba(18, 26, 30, 0.48), rgba(18, 26, 30, 0.8));
+          box-shadow: inset 0 0 0 1px rgba(225, 235, 236, 0.18), 0 3px 5px rgba(0, 0, 0, 0.25);
+          transform-origin: 50% 100%;
+          transition: transform 0.42s cubic-bezier(.2, .75, .25, 1), box-shadow 0.42s ease;
+        }
+        .dw-door::before {
+          content: ""; position: absolute; top: 4px; right: 18%; left: 18%; height: 2px;
+          border-radius: 8px; background: rgba(225, 231, 232, 0.6);
+        }
+        .dw-door.open { transform: rotateX(66deg) translateY(7px) translateZ(4px); box-shadow: 0 12px 10px rgba(0, 0, 0, 0.32); }
+        @keyframes dw-spray-spin { to { transform: rotate(360deg); } }
+        @keyframes dw-drop-fall {
+          0% { opacity: 0; transform: translateY(-4px) scale(0.75); }
+          22% { opacity: 0.85; }
+          82% { opacity: 0.62; }
+          100% { opacity: 0; transform: translateY(28px) scale(1); }
+        }
+        @keyframes dw-water-pulse { 0%, 100% { transform: scaleX(0.97); } 50% { transform: scaleX(1.02); } }
+        @keyframes dw-wave-drift { 0%, 100% { transform: translateX(-3%); } 50% { transform: translateX(3%); } }
+        @media (prefers-reduced-motion: reduce) {
+          .machine.spinning .dw-spray, .machine.spinning .dw-drop, .machine.spinning .dw-water,
+          .machine.spinning .dw-wave-a, .machine.spinning .dw-wave-b {
+          animation-duration: 0.001ms !important; animation-iteration-count: 1 !important;
+          }
         }
   `,
   oven: () => `
@@ -2806,7 +2919,7 @@ const ILLUSTRATION_CSS = {
 };
 
 function illustrationCss(type, color) {
-  const family = LAUNDRY_TYPES.includes(type) ? "laundry" : type;
+  const family = type === "dishwasher" ? "dishwasher" : LAUNDRY_TYPES.includes(type) ? "laundry" : type;
   const fn = ILLUSTRATION_CSS[family] || ILLUSTRATION_CSS.laundry;
   return fn(color);
 }
@@ -2941,6 +3054,34 @@ function illustrationHtml(type, ctx) {
     .filter(Boolean)
     .join(" ");
 
+  if (type === "dishwasher") {
+    return `
+        <div class="machine ${ctx.spinning ? "spinning" : ""}">
+          <div class="dw-body">
+            <div class="dw-controls"><div class="dw-screen"></div></div>
+            <div class="dw-cavity">
+              <div class="dw-dishes" aria-hidden="true">
+                <span class="dw-plate dw-plate-a"></span>
+                <span class="dw-plate dw-plate-b"></span>
+                <span class="dw-plate dw-plate-c"></span>
+                <span class="dw-plate dw-plate-d"></span>
+              </div>
+              <div class="dw-rack"></div>
+              <div class="dw-spray" aria-hidden="true"><span class="dw-spray-hub"></span></div>
+              <div class="dw-drops" aria-hidden="true">
+                <i class="dw-drop dw-drop-a"></i><i class="dw-drop dw-drop-b"></i>
+                <i class="dw-drop dw-drop-c"></i><i class="dw-drop dw-drop-d"></i>
+                <i class="dw-drop dw-drop-e"></i>
+              </div>
+              <div class="dw-water" aria-hidden="true">
+                <span class="dw-wave dw-wave-a"></span><span class="dw-wave dw-wave-b"></span>
+              </div>
+            </div>
+            <div class="dw-door ${ctx.doorOpen ? "open" : ""}" aria-hidden="true"></div>
+          </div>
+        </div>`;
+  }
+
   if (LAUNDRY_TYPES.includes(type)) {
     const glassContent = {
       washer: `
@@ -2954,7 +3095,6 @@ function illustrationHtml(type, ctx) {
           <div class="garment g2"></div>
           <div class="garment g3"></div>
         </div>`,
-      dishwasher: `<div class="spray-arm"></div>`,
     }[type];
     return `
         <div class="machine ${ctx.spinning ? "spinning" : ""}">

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -1631,6 +1631,40 @@ function stringifyValueMap(valueMap) {
   return Object.keys(valueMap).map((key) => `${key}: ${valueMap[key]}`).join("\n");
 }
 
+// Dishwasher integrations do not share one phase vocabulary. Keep the
+// visual model deliberately small and safe: an optional phase entity can add
+// a known phase class, but a missing, unavailable, or new vendor value simply
+// leaves the normal dishwasher animation in place.
+const DISHWASHER_PHASE_ALIASES = {
+  prewash: "prewash",
+  "pre wash": "prewash",
+  "pre rinse": "prewash",
+  prerinsing: "prewash",
+  mainwash: "mainwash",
+  "main wash": "mainwash",
+  wash: "mainwash",
+  washing: "mainwash",
+  rinse: "rinsing",
+  rinsing: "rinsing",
+  drying: "drying",
+  dry: "drying",
+  "ado drying": "ado_drying",
+  adodrying: "ado_drying",
+};
+const DISHWASHER_PHASES = new Set(Object.values(DISHWASHER_PHASE_ALIASES));
+
+function normalizeDishwasherPhase(raw, phaseMap) {
+  if (raw === undefined || raw === null) return "";
+  const text = String(raw).trim();
+  if (["unknown", "unavailable", "none", ""].includes(text.toLowerCase())) return "";
+
+  const mapped = mapInfoValue(text, phaseMap);
+  const candidate = mapped === null || mapped === undefined ? text : mapped;
+  const key = stripAccents(String(candidate).trim()).toLowerCase().replace(/[\\_-]+/g, " ").replace(/\\s+/g, " ");
+  const phase = DISHWASHER_PHASE_ALIASES[key] || key.replace(/ /g, "_");
+  return DISHWASHER_PHASES.has(phase) ? phase : "";
+}
+
 function formatInfoValue(st, hass, valueMap) {
   const mapped = mapInfoValue(st.state, valueMap);
   // A mapped label replaces the value outright: appending a unit to it
@@ -2292,6 +2326,46 @@ const ILLUSTRATION_CSS = {
         .machine.spinning .dw-water { opacity: 0.82; animation: dw-water-pulse 2.2s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
         .machine.spinning .dw-wave-a { animation: dw-wave-drift 1.8s ease-in-out infinite; animation-delay: var(--anim-offset, 0s); }
         .machine.spinning .dw-wave-b { animation: dw-wave-drift 2.4s ease-in-out infinite reverse; animation-delay: var(--anim-offset, 0s); }
+        .dw-heat {
+          position: absolute; top: 17px; right: 25%; left: 25%; z-index: 6;
+          height: 28px; opacity: 0; pointer-events: none;
+          transition: opacity 0.35s ease;
+        }
+        .dw-heat i {
+          position: absolute; bottom: 0; width: 3px; height: 16px;
+          border-radius: 50%; opacity: 0;
+          background: linear-gradient(180deg, rgba(255, 193, 7, 0), rgba(255, 112, 67, 0.9));
+          filter: blur(0.35px);
+        }
+        .dw-heat-a { left: 12%; }
+        .dw-heat-b { left: 42%; height: 19px !important; }
+        .dw-heat-c { right: 12%; height: 14px !important; }
+        .machine.phase-drying .dw-heat,
+        .machine.phase-ado_drying .dw-heat { opacity: 0.8; }
+        .machine.phase-ado_drying .dw-heat { top: 8px; height: 34px; opacity: 1; }
+        .machine.phase-drying .dw-heat i,
+        .machine.phase-ado_drying .dw-heat i {
+          animation: dw-heat-rise 2.4s ease-in-out infinite; animation-delay: var(--anim-offset, 0s);
+        }
+        .machine.phase-drying .dw-heat-b,
+        .machine.phase-ado_drying .dw-heat-b { animation-delay: calc(-0.8s + var(--anim-offset, 0s)); }
+        .machine.phase-drying .dw-heat-c,
+        .machine.phase-ado_drying .dw-heat-c { animation-delay: calc(-1.5s + var(--anim-offset, 0s)); }
+        .machine.phase-drying .dw-spray,
+        .machine.phase-drying .dw-drop,
+        .machine.phase-drying .dw-water,
+        .machine.phase-drying .dw-wave-a,
+        .machine.phase-drying .dw-wave-b,
+        .machine.phase-ado_drying .dw-spray,
+        .machine.phase-ado_drying .dw-drop,
+        .machine.phase-ado_drying .dw-water,
+        .machine.phase-ado_drying .dw-wave-a,
+        .machine.phase-ado_drying .dw-wave-b {
+          animation-play-state: paused; opacity: 0.12;
+        }
+        .machine.phase-ado_drying .dw-door {
+          box-shadow: inset 0 0 0 1px rgba(225, 235, 236, 0.18), 0 0 8px rgba(255, 112, 67, 0.35);
+        }
         .dw-door {
           position: absolute; top: 22px; right: 8px; bottom: 8px; left: 8px; z-index: 5;
           padding: 0; border: 3px solid #34383b; border-radius: 4px;
@@ -2314,9 +2388,15 @@ const ILLUSTRATION_CSS = {
         }
         @keyframes dw-water-pulse { 0%, 100% { transform: scaleX(0.97); } 50% { transform: scaleX(1.02); } }
         @keyframes dw-wave-drift { 0%, 100% { transform: translateX(-3%); } 50% { transform: translateX(3%); } }
+        @keyframes dw-heat-rise {
+          0% { opacity: 0; transform: translateY(4px) scaleY(0.8) rotate(-4deg); }
+          35% { opacity: 0.62; }
+          100% { opacity: 0; transform: translateY(-18px) scaleY(1.15) rotate(5deg); }
+        }
         @media (prefers-reduced-motion: reduce) {
           .machine.spinning .dw-spray, .machine.spinning .dw-drop, .machine.spinning .dw-water,
-          .machine.spinning .dw-wave-a, .machine.spinning .dw-wave-b {
+          .machine.spinning .dw-wave-a, .machine.spinning .dw-wave-b,
+          .machine.phase-drying .dw-heat i, .machine.phase-ado_drying .dw-heat i {
           animation-duration: 0.001ms !important; animation-iteration-count: 1 !important;
           }
         }
@@ -3050,13 +3130,14 @@ function illustrationHtml(type, ctx) {
     ctx.heating ? "heating" : "",
     ctx.lit ? "lit" : "",
     ctx.doorOpen ? "open" : "",
+    ctx.phase && DISHWASHER_PHASES.has(ctx.phase) ? `phase-${ctx.phase}` : "",
   ]
     .filter(Boolean)
     .join(" ");
 
   if (type === "dishwasher") {
     return `
-        <div class="machine ${ctx.spinning ? "spinning" : ""}">
+        <div class="machine ${cls}">
           <div class="dw-body">
             <div class="dw-controls"><div class="dw-screen"></div></div>
             <div class="dw-cavity">
@@ -3076,6 +3157,9 @@ function illustrationHtml(type, ctx) {
               <div class="dw-water" aria-hidden="true">
                 <span class="dw-wave dw-wave-a"></span><span class="dw-wave dw-wave-b"></span>
               </div>
+            </div>
+            <div class="dw-heat" aria-hidden="true">
+              <i class="dw-heat-a"></i><i class="dw-heat-b"></i><i class="dw-heat-c"></i>
             </div>
             <div class="dw-door ${ctx.doorOpen ? "open" : ""}" aria-hidden="true"></div>
           </div>
@@ -3592,6 +3676,12 @@ class ApplianceCard extends HTMLElement {
     // Alerts
     const alerts = cfg.alerts_entity ? activeAlerts(hass, cfg.alerts_entity) : [];
 
+    // Phase is optional. A phase sensor is useful for richer dishwasher
+    // animation, but integrations that do not expose one must render exactly
+    // as before. Unknown vendor phases are intentionally ignored as well.
+    const phaseState = cfg.phase_entity ? stateObj(hass, cfg.phase_entity) : null;
+    const phase = phaseState ? normalizeDishwasherPhase(phaseState.state, cfg.phase_map) : "";
+
     // Extra info chips
     const infoEntities = (cfg.info_entities || [])
       .map((e) => (typeof e === "string" ? { entity: e } : e))
@@ -4033,6 +4123,7 @@ class ApplianceCard extends HTMLElement {
       zoneColumns: zoneColumns(zones.length, cfg.zones_layout),
       anyZoneOn: zones.some((z) => z.on),
       childLock,
+      phase: applianceType === "dishwasher" ? phase : "",
     };
 
     // A plain on/off control, for the types that have no cycle to start or
@@ -4065,6 +4156,7 @@ class ApplianceCard extends HTMLElement {
       illustrationCtx.ice, illustrationCtx.noWater, illustrationCtx.speed,
       illustrationCtx.fanLevel, illustrationCtx.boost, illustrationCtx.keepWarm,
       illustrationCtx.anyZoneOn,
+      illustrationCtx.phase,
     ].join(",");
     if (animKey !== this._animKey) {
       this._animKey = animKey;

--- a/dist/ha-appliance-card.js
+++ b/dist/ha-appliance-card.js
@@ -2316,6 +2316,28 @@ const ILLUSTRATION_CSS = {
         }
         .dw-wave-a { top: 2px; }
         .dw-wave-b { top: 6px; left: 8%; opacity: 0.6; }
+        .dw-fan {
+          position: absolute; top: 12%; left: 50%; z-index: 3;
+          width: 16px; height: 16px; border: 1px solid rgba(255, 193, 7, 0.42);
+          border-radius: 50%; opacity: 0; transform: translateX(-50%);
+        }
+        .dw-fan::before,
+        .dw-fan::after {
+          content: ""; position: absolute; top: 50%; left: 50%;
+          width: 12px; height: 3px; border-radius: 50%;
+          background: rgba(255, 112, 67, 0.72); transform-origin: 0 50%;
+        }
+        .dw-fan::before { transform: translate(-1px, -50%) rotate(25deg); }
+        .dw-fan::after { transform: translate(-1px, -50%) rotate(115deg); }
+        .dw-dry-heat { position: absolute; inset: 13% 24% 30%; z-index: 3; opacity: 0; pointer-events: none; }
+        .dw-dry-heat i {
+          position: absolute; bottom: 0; width: 2px; height: 13px; border-radius: 50%;
+          background: linear-gradient(180deg, rgba(255, 193, 7, 0), rgba(255, 112, 67, 0.72));
+          opacity: 0;
+        }
+        .dw-dry-heat-a { left: 20%; }
+        .dw-dry-heat-b { left: 48%; height: 17px !important; }
+        .dw-dry-heat-c { right: 20%; height: 11px !important; }
         .machine.spinning .dw-spray { opacity: 0.95; animation: dw-spray-spin 2.8s linear infinite; animation-delay: var(--anim-offset, 0s); }
         .machine.spinning .dw-drop { animation: dw-drop-fall 1.65s ease-in infinite; animation-delay: var(--anim-offset, 0s); }
         .machine.spinning .dw-drop-a { animation-delay: calc(-0.3s + var(--anim-offset, 0s)); }
@@ -2340,16 +2362,24 @@ const ILLUSTRATION_CSS = {
         .dw-heat-a { left: 12%; }
         .dw-heat-b { left: 42%; height: 19px !important; }
         .dw-heat-c { right: 12%; height: 14px !important; }
-        .machine.phase-drying .dw-heat,
-        .machine.phase-ado_drying .dw-heat { opacity: 0.8; }
+        .machine.phase-drying .dw-cavity {
+          box-shadow: inset 0 0 18px rgba(255, 112, 67, 0.38);
+        }
+        .machine.phase-drying .dw-fan {
+          opacity: 0.82; animation: dw-fan-spin 1.2s linear infinite; animation-delay: var(--anim-offset, 0s);
+        }
+        .machine.phase-drying .dw-dry-heat { opacity: 0.9; }
+        .machine.phase-drying .dw-dry-heat i {
+          animation: dw-dry-heat-rise 2.6s ease-in-out infinite; animation-delay: var(--anim-offset, 0s);
+        }
+        .machine.phase-drying .dw-dry-heat-b { animation-delay: calc(-0.85s + var(--anim-offset, 0s)); }
+        .machine.phase-drying .dw-dry-heat-c { animation-delay: calc(-1.7s + var(--anim-offset, 0s)); }
+        .machine.phase-ado_drying .dw-heat { opacity: 1; }
         .machine.phase-ado_drying .dw-heat { top: 8px; height: 34px; opacity: 1; }
-        .machine.phase-drying .dw-heat i,
         .machine.phase-ado_drying .dw-heat i {
           animation: dw-heat-rise 2.4s ease-in-out infinite; animation-delay: var(--anim-offset, 0s);
         }
-        .machine.phase-drying .dw-heat-b,
         .machine.phase-ado_drying .dw-heat-b { animation-delay: calc(-0.8s + var(--anim-offset, 0s)); }
-        .machine.phase-drying .dw-heat-c,
         .machine.phase-ado_drying .dw-heat-c { animation-delay: calc(-1.5s + var(--anim-offset, 0s)); }
         .machine.phase-drying .dw-spray,
         .machine.phase-drying .dw-drop,
@@ -2388,6 +2418,12 @@ const ILLUSTRATION_CSS = {
         }
         @keyframes dw-water-pulse { 0%, 100% { transform: scaleX(0.97); } 50% { transform: scaleX(1.02); } }
         @keyframes dw-wave-drift { 0%, 100% { transform: translateX(-3%); } 50% { transform: translateX(3%); } }
+        @keyframes dw-fan-spin { to { transform: translateX(-50%) rotate(360deg); } }
+        @keyframes dw-dry-heat-rise {
+          0% { opacity: 0; transform: translateY(3px) scaleY(0.8); }
+          35% { opacity: 0.55; }
+          100% { opacity: 0; transform: translateY(-12px) scaleY(1.1); }
+        }
         @keyframes dw-heat-rise {
           0% { opacity: 0; transform: translateY(4px) scaleY(0.8) rotate(-4deg); }
           35% { opacity: 0.62; }
@@ -2396,7 +2432,8 @@ const ILLUSTRATION_CSS = {
         @media (prefers-reduced-motion: reduce) {
           .machine.spinning .dw-spray, .machine.spinning .dw-drop, .machine.spinning .dw-water,
           .machine.spinning .dw-wave-a, .machine.spinning .dw-wave-b,
-          .machine.phase-drying .dw-heat i, .machine.phase-ado_drying .dw-heat i {
+          .machine.phase-drying .dw-fan, .machine.phase-drying .dw-dry-heat i,
+          .machine.phase-ado_drying .dw-heat i {
           animation-duration: 0.001ms !important; animation-iteration-count: 1 !important;
           }
         }
@@ -3156,6 +3193,10 @@ function illustrationHtml(type, ctx) {
               </div>
               <div class="dw-water" aria-hidden="true">
                 <span class="dw-wave dw-wave-a"></span><span class="dw-wave dw-wave-b"></span>
+              </div>
+              <div class="dw-fan" aria-hidden="true"></div>
+              <div class="dw-dry-heat" aria-hidden="true">
+                <i class="dw-dry-heat-a"></i><i class="dw-dry-heat-b"></i><i class="dw-dry-heat-c"></i>
               </div>
             </div>
             <div class="dw-heat" aria-hidden="true">

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -449,6 +449,26 @@ check('lave-vaisselle : en marche porte la classe spinning',
 contains('lave-vaisselle : en marche anime le bras de lavage',
   dishwasherRunning, 'animation: dw-spray-spin');
 
+const dishwasherDrying = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
+                                 phase_entity: 'sensor.dw_phase' },
+  { 'sensor.dw': { state: 'Running', attributes: {} },
+    'sensor.dw_phase': { state: 'Ado Drying', attributes: {} } });
+check('lave-vaisselle : Ado Drying donne une classe de phase',
+  machineCls(dishwasherDrying).includes('phase-ado_drying'), true);
+contains('lave-vaisselle : Ado Drying affiche la chaleur',
+  dishwasherDrying, 'class="dw-heat"');
+contains('lave-vaisselle : Ado Drying anime la chaleur',
+  dishwasherDrying, 'animation: dw-heat-rise');
+
+const dishwasherNoPhase = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
+                                  phase_entity: 'sensor.dw_phase' },
+  { 'sensor.dw': { state: 'Running', attributes: {} },
+    'sensor.dw_phase': { state: 'Unavailable', attributes: {} } });
+check('lave-vaisselle : phase indisponible ne casse pas la classe',
+  machineCls(dishwasherNoPhase).includes('phase-'), false);
+contains('lave-vaisselle : phase indisponible conserve le lavage',
+  dishwasherNoPhase, 'animation: dw-spray-spin');
+
 // ── Escaping ─────────────────────────────────────────────────────────────────
 
 const quoted = render({ appliance_type: 'cooktop', state_entity: 'sensor.hob',

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -429,6 +429,22 @@ check('non-regression lave-linge : etat', stateLine(washer), 'Running');
 contains('non-regression lave-linge : illustration du tambour', washer, 'water-level');
 check('non-regression lave-linge : porte fermee', infoLine(washer, 'Door closed'), '');
 
+const dishwasherClosed = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
+                                  door_entity: 'binary_sensor.dw_door' },
+  { 'sensor.dw': { state: 'Idle', attributes: {} },
+    'binary_sensor.dw_door': { state: 'off', attributes: {} } });
+check('lave-vaisselle : illustration dediee', /class="dw-body"/.test(dishwasherClosed), true);
+check('lave-vaisselle : pas de corps lave-linge', /class="mbody"/.test(dishwasherClosed), false);
+
+const dishwasherRunning = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
+                                   door_entity: 'binary_sensor.dw_door' },
+  { 'sensor.dw': { state: 'Running', attributes: {} },
+    'binary_sensor.dw_door': { state: 'on', attributes: {} } });
+check('lave-vaisselle : porte ouverte porte la classe open',
+  /class="dw-door open"/.test(dishwasherRunning), true);
+contains('lave-vaisselle : en marche anime le bras de lavage',
+  dishwasherRunning, 'animation: dw-spray-spin');
+
 // ── Escaping ─────────────────────────────────────────────────────────────────
 
 const quoted = render({ appliance_type: 'cooktop', state_entity: 'sensor.hob',

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -452,13 +452,26 @@ contains('lave-vaisselle : en marche anime le bras de lavage',
 const dishwasherDrying = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
                                  phase_entity: 'sensor.dw_phase' },
   { 'sensor.dw': { state: 'Running', attributes: {} },
+    'sensor.dw_phase': { state: 'Drying', attributes: {} } });
+check('lave-vaisselle : Drying donne une classe de phase',
+  machineCls(dishwasherDrying).includes('phase-drying'), true);
+contains('lave-vaisselle : Drying affiche le ventilateur interne',
+  dishwasherDrying, 'class="dw-fan"');
+contains('lave-vaisselle : Drying affiche la chaleur interne',
+  dishwasherDrying, 'class="dw-dry-heat"');
+contains('lave-vaisselle : Drying anime le ventilateur',
+  dishwasherDrying, 'animation: dw-fan-spin');
+
+const dishwasherAdoDrying = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
+                                    phase_entity: 'sensor.dw_phase' },
+  { 'sensor.dw': { state: 'Running', attributes: {} },
     'sensor.dw_phase': { state: 'Ado Drying', attributes: {} } });
 check('lave-vaisselle : Ado Drying donne une classe de phase',
-  machineCls(dishwasherDrying).includes('phase-ado_drying'), true);
+  machineCls(dishwasherAdoDrying).includes('phase-ado_drying'), true);
 contains('lave-vaisselle : Ado Drying affiche la chaleur',
-  dishwasherDrying, 'class="dw-heat"');
+  dishwasherAdoDrying, 'class="dw-heat"');
 contains('lave-vaisselle : Ado Drying anime la chaleur',
-  dishwasherDrying, 'animation: dw-heat-rise');
+  dishwasherAdoDrying, 'animation: dw-heat-rise');
 
 const dishwasherNoPhase = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
                                   phase_entity: 'sensor.dw_phase' },

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -435,6 +435,8 @@ const dishwasherClosed = render({ appliance_type: 'dishwasher', state_entity: 's
     'binary_sensor.dw_door': { state: 'off', attributes: {} } });
 check('lave-vaisselle : illustration dediee', /class="dw-body"/.test(dishwasherClosed), true);
 check('lave-vaisselle : pas de corps lave-linge', /class="mbody"/.test(dishwasherClosed), false);
+check('lave-vaisselle : inactiv ne porte pas spinning',
+  machineCls(dishwasherClosed).includes('spinning'), false);
 
 const dishwasherRunning = render({ appliance_type: 'dishwasher', state_entity: 'sensor.dw',
                                    door_entity: 'binary_sensor.dw_door' },
@@ -442,6 +444,8 @@ const dishwasherRunning = render({ appliance_type: 'dishwasher', state_entity: '
     'binary_sensor.dw_door': { state: 'on', attributes: {} } });
 check('lave-vaisselle : porte ouverte porte la classe open',
   /class="dw-door open"/.test(dishwasherRunning), true);
+check('lave-vaisselle : en marche porte la classe spinning',
+  machineCls(dishwasherRunning).includes('spinning'), true);
 contains('lave-vaisselle : en marche anime le bras de lavage',
   dishwasherRunning, 'animation: dw-spray-spin');
 


### PR DESCRIPTION
Follow-up to #9, split out as requested in review.

## Summary

- add a dedicated CSS-only dishwasher illustration with a square, bottom-hinged door
- show the rack, plates, spray arm, droplets and water waves
- animate the spray arm, droplets and water while the appliance is running
- make the closed door visibly closed with a darker tint and a highlight, while keeping the appliance readable
- remove the obsolete laundry spray-arm rules and keyframes
- restore CARD_VERSION to 2.2.1 for the release maintainer to bump

## Tests

- node --check dist/ha-appliance-card.js
- node test/run.mjs
- 364/364 assertions pass
- tests cover the dedicated dishwasher markup, open-door class and running spray-arm animation
- dist/ha-appliance-card.js remains ASCII-only